### PR TITLE
New feature: make floating TOC, also add options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 /*.zip
+.idea/

--- a/src/content-script.js
+++ b/src/content-script.js
@@ -1,0 +1,28 @@
+async function applyStyles() {
+    const options = await getOptions();
+    console.log(options);
+
+    if(options.removeSidebar) {
+        console.log("Removing sidebar");
+        const mainColumn = document.querySelector(MainColumnSelector);
+        const sidebar = document.querySelector(SidebarColumnSelector);
+
+        if (sidebar) {
+            sidebar.remove();
+        }
+
+        if(mainColumn) {
+            mainColumn.classList.add(MainColumnCssClass);
+        }
+    }
+
+    if (options.floatingTOC) {
+        console.log("Applying floating TOC");
+        const toc = document.querySelector(DocOutlineSelector);
+        if (toc) {
+            toc.classList.add(FloatingTOCCssClass);
+        }
+    }
+}
+
+applyStyles();

--- a/src/core.js
+++ b/src/core.js
@@ -1,0 +1,31 @@
+// declare constants
+const OptionRemoveSidebar = "removeSidebar";
+const OptionFloatingTOC = "floatingTOC";
+
+const MainColumnSelector = ".column.is-8-desktop";
+const MainColumnCssClass = "rf-ms-learn-main-column";
+
+const SidebarColumnSelector = "div#ms--additional-resources";
+
+const DocOutlineSelector = "#center-doc-outline";
+const FloatingTOCCssClass = "rf-ms-learn-floating-toc";
+
+async function getOptions() {
+    const current = await chrome.storage.sync.get();
+    return {
+        removeSidebar: current[OptionRemoveSidebar] ?? true,
+        floatingTOC: current[OptionFloatingTOC] ?? false,
+    };
+}
+
+// async function loadConfig(id, defaultValue) {
+//     return await chrome.storage.sync.get([id]) || defaultValue;
+// }
+//
+// async function shouldRemoveSidebar() {
+//     return await loadConfig(RemoveSidebar, true);
+// }
+//
+// async function shouldFloatTOC() {
+//     return await loadConfig(FloatingTOC, false);
+// }

--- a/src/core.js
+++ b/src/core.js
@@ -17,15 +17,3 @@ async function getOptions() {
         floatingTOC: current[OptionFloatingTOC] ?? false,
     };
 }
-
-// async function loadConfig(id, defaultValue) {
-//     return await chrome.storage.sync.get([id]) || defaultValue;
-// }
-//
-// async function shouldRemoveSidebar() {
-//     return await loadConfig(RemoveSidebar, true);
-// }
-//
-// async function shouldFloatTOC() {
-//     return await loadConfig(FloatingTOC, false);
-// }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,6 +9,10 @@
         "48": "img/icon-48.png",
         "128": "img/icon-128.png"
     },
+    "permissions": [
+        "storage",
+        "tabs"
+    ],
     "content_scripts": [
         {
             "matches": [
@@ -16,7 +20,15 @@
             ],
             "css": [
                 "styles.css"
+            ],
+            "js": [
+                "core.js",
+                "content-script.js"
             ]
         }
-    ]
+    ],
+    "action": {
+        "default_title": "Refined Microsoft Learn",
+        "default_popup": "popup.html"
+    }
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Options</title>
+    <style>
+        html, body {
+            font-family: segoe ui, Candara, lucida grande, lucida sans unicode, lucida sans, Tahoma, sans-serif;
+            font-size: 14px;
+            color: #e8eef2;
+            padding: 0;
+            margin: 0;
+        }
+
+        body {
+            width: 300px;
+        }
+
+        .header {
+            background-color: #333337;
+            border-bottom: #4E4E4E 1px solid;
+            padding-bottom: 2px;
+            padding-top: 2px;
+        }
+
+        .header img {
+            width: 14px;
+            position: absolute;
+            top: 5px;
+            left: 4px;
+        }
+
+        .header h2 {
+            padding-top: 0;
+            padding-left: 22px;
+        }
+
+        h2 {
+            font-size: 14px;
+            font-style: normal;
+            font-weight: normal;
+            margin: 0;
+        }
+
+        .content {
+            padding: 5px;
+            background: #252526;
+        }
+
+        .content label {
+            display: inline-block;
+            margin-top: -60px;
+        }
+
+        .content .hint {
+            font-size: 12px;
+            font-style: italic;
+            color: #979797;
+            margin-left: 8px;
+        }
+
+        .content .subtitle {
+            font-size: 12px;
+            padding-bottom: 5px;
+        }
+
+        .content input[type="button"] {
+            /*width: 100%;*/
+            height: 18px;
+            background: #66B347;
+            border: none;
+            color: #e8eef2;
+            font-size: 12px;
+            font-weight: normal;
+            cursor: pointer;
+            border-radius: 3px;
+        }
+
+        .bottom-help {
+            padding-top: 5px;
+            font-size: 12px;
+            color: rgba(151, 151, 151, 0.87);
+        }
+
+        .footer {
+            background-color: #333337;
+            font-size: 14px;
+            border-top: #4E4E4E 1px solid;
+            padding-left: 3px;
+            padding-bottom: 2px;
+        }
+
+        a {
+            text-decoration: none;
+            color: #5e9ff9;
+        }
+
+        a:hover {
+            color: #e8eef2;
+        }
+    </style>
+</head>
+<body>
+<div class="header">
+    <img src="img/icon-48.png" alt="icon"/>
+    <h2>Refined Microsoft Learn</h2>
+</div>
+
+<div class="content">
+
+    <div class="subtitle">
+        Makes Microsoft Learn more readable by removing the sidebar and other distractions.
+    </div>
+
+    <label for="removeSidebar">
+        <input type="checkbox" id="removeSidebar" checked=""/>remove sidebar
+    </label>
+    <div class="hint">
+        Removes sidebar from the right side of the page.
+    </div>
+
+    <label for="floatingTOC">
+        <input type="checkbox" id="floatingTOC" checked=""/>floating TOC
+    </label>
+    <div class="hint">
+        Moves the table of contents to the right top side of the page and makes it floating.
+    </div>
+
+    <div class="bottom-help">
+        To apply changes, <a id="refresh" href="#">refresh</a> the page.
+    </div>
+
+</div>
+
+<div class="footer">
+    <a href="https://github.com/merill/refined-microsoft-learn" target="_blank">GitHub</a>
+</div>
+<script src="core.js"></script>
+<script src="popup.js"></script>
+</body>
+</html>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,0 +1,22 @@
+async function initHandler(id, value) {
+    document.getElementById(id).checked = value;
+    document.getElementById(id).addEventListener("click", function () {
+        const currentValue = document.getElementById(id).checked;
+        console.log(id + " -> " + currentValue);
+        chrome.storage.sync.set({[id]: currentValue});
+    });
+}
+
+
+async function init() {
+    const options = await getOptions();
+    await initHandler(OptionRemoveSidebar, options.removeSidebar);
+    await initHandler(OptionFloatingTOC, options.floatingTOC);
+}
+
+init();
+
+// add "refresh" button to popup
+document.getElementById("refresh").addEventListener("click", function () {
+    chrome.tabs.reload();
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,7 +1,16 @@
-div#ms--additional-resources {
-    display: none !important;
+.rf-ms-learn-main-column {
+    width: 95% !important;
 }
 
-.column.is-8-desktop {
-    width: 95% !important;
+.rf-ms-learn-floating-toc {
+    position: fixed;
+    top: 0;
+    right: 0;
+    z-index: 9999;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-bottom: 10px;
+    opacity: 0.9;
+    background: var(--theme-text-invert);
+    border: .125rem solid var(--theme-border);
 }


### PR DESCRIPTION
In addition to my previous comment #2 I have done it for myself and sharing if you want to merge.

I've added options to the browser button to turn on and off sidebar and TOC:

![image](https://github.com/merill/refined-microsoft-learn/assets/3155189/07f72b32-ee20-4126-8069-11aede86c6be)

TOC is moved out of page top and becomes a floating overlay on top-right:

![image](https://github.com/merill/refined-microsoft-learn/assets/3155189/6124106f-8335-4117-b807-380442f20689)

I had to change your css because it's now enabled partially based on options selectors.

The manifest has two additional permissions:

- "storage" - to persist user options.
- "tabs" - to reload current tab from the options dialog.

I've been using this for a day or so now, seems to be fine.